### PR TITLE
Fix for entrypoint.sh add-user command and README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker pull ghcr.io/aeron/socks5-dante-docker
 Running a container is pretty straightforward:
 
 ```sh
-docker -d --restart unless-stopped --name dante \
+docker run -d --restart unless-stopped --name dante \
     -p 1080/1080:tcp \
     -e WORKERS=4 \
     -e CONFIG=/etc/sockd.conf \
@@ -89,7 +89,7 @@ docker exec -it dante /srv/entrypoint.sh del-user [NAME]
 To save or restore existing users, mount `/etc/passwd` and `/etc/shadow` files:
 
 ```sh
-docker -d --restart unless-stopped --name dante \
+docker run -d --restart unless-stopped --name dante \
     -p 1080/1080:tcp \
     -v /path/to/passwd:/etc/passwd:rw \
     -v /path/to/shadow:/etc/shadow:rw \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,13 @@ _strip_name() {
     echo "$1" | tr '@&+.:' '-' | tr -d '=!%^#$\/()[]{}|;<>, ' | xargs
 }
 
-set -- "$1" "$(_strip_name "$2")"
+original_name="$2"
+stripped_name="$(_strip_name "$2")"
+password="$3"
+
+set -- "$1" "$stripped_name" "$password"
 if [ -z "$2" ]; then
-    set -- "$1" 'socks'
+    set -- "$1" 'socks' "$password"
 fi
 
 # shellcheck disable=SC2016

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,9 @@ _strip_name() {
     echo "$1" | tr '@&+.:' '-' | tr -d '=!%^#$\/()[]{}|;<>, ' | xargs
 }
 
-original_name="$2"
-stripped_name="$(_strip_name "$2")"
-password="$3"
-
-set -- "$1" "$stripped_name" "$password"
+set -- "$1" "$(_strip_name "$2")" "$3"
 if [ -z "$2" ]; then
-    set -- "$1" 'socks' "$password"
+    set -- "$1" 'socks' "$3"
 fi
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
This PR addresses an issue where the add-user command in the script was generating a random password instead of using the provided password. The problem was caused by the script modifying the positional parameters in a way that the third argument (password) was lost.