### PR TITLE
Some issues with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A compact [Dante](https://www.inet.no/dante/) SOCKS5 proxy container image based
 
 ## Usage
 
-The container image is available as [`docker.io/aeron/socks5-dante-docker`][docker] and
+The container image is available as [`docker.io/aeron/socks5-dante-proxy`][docker] and
 [`ghcr.io/Aeron/socks5-dante-docker`][github]. You can use both interchangeably.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ A compact [Dante](https://www.inet.no/dante/) SOCKS5 proxy container image based
 
 ## Usage
 
-The container image is available as [`docker.io/aeron/socks5-dante-docker`][docker] and
-[`ghcr.io/Aeron/socks5-dante-docker`][github]. You can use both interchangeably.
+The container image is available as [`docker.io/aeron/socks5-dante-proxy`][docker] and
+[`ghcr.io/aeron/socks5-dante-proxy`][github]. You can use both interchangeably.
 
 ```sh
-docker pull docker.io/aeron/socks5-dante-docker
+docker pull docker.io/aeron/socks5-dante-proxy
 # …or…
-docker pull ghcr.io/aeron/socks5-dante-docker
+docker pull ghcr.io/aeron/socks5-dante-proxy
 ```
 
-[docker]: https://hub.docker.com/r/aeron/socks5-dante-docker
+[docker]: https://hub.docker.com/repository/docker/aeron/socks5-dante-proxy
 [github]: https://github.com/Aeron/socks5-dante-proxy/pkgs/container/socks5-dante-proxy
 
 ### Container Running

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A compact [Dante](https://www.inet.no/dante/) SOCKS5 proxy container image based
 
 ## Usage
 
-The container image is available as [`docker.io/aeron/socks5-dante-proxy`][docker] and
+The container image is available as [`docker.io/aeron/socks5-dante-docker`][docker] and
 [`ghcr.io/Aeron/socks5-dante-docker`][github]. You can use both interchangeably.
 
 ```sh
-docker pull docker.io/aeron/socks5-dante-docker
+docker pull docker.io/aeron/socks5-dante-proxy
 # …or…
-docker pull ghcr.io/aeron/socks5-dante-docker
+docker pull ghcr.io/aeron/socks5-dante-proxy
 ```
 
 [docker]: https://hub.docker.com/r/aeron/socks5-dante-docker

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The container image is available as [`docker.io/aeron/socks5-dante-docker`][dock
 [`ghcr.io/Aeron/socks5-dante-docker`][github]. You can use both interchangeably.
 
 ```sh
-docker pull docker.io/aeron/socks5-dante-proxy
+docker pull docker.io/aeron/socks5-dante-docker
 # …or…
-docker pull ghcr.io/aeron/socks5-dante-proxy
+docker pull ghcr.io/aeron/socks5-dante-docker
 ```
 
 [docker]: https://hub.docker.com/r/aeron/socks5-dante-docker
@@ -29,7 +29,7 @@ docker run -d --restart unless-stopped --name dante \
     -p 1080/1080:tcp \
     -e WORKERS=4 \
     -e CONFIG=/etc/sockd.conf \
-    docker.io/aeron/socks5-dante-docker:latest
+    docker.io/aeron/socks5-dante-proxy:latest
 ```
 
 By default, the number of simultaneous workers (the `WORKERS` environment variable)
@@ -93,7 +93,7 @@ docker run -d --restart unless-stopped --name dante \
     -p 1080/1080:tcp \
     -v /path/to/passwd:/etc/passwd:rw \
     -v /path/to/shadow:/etc/shadow:rw \
-    docker.io/aeron/socks5-dante-docker:latest
+    docker.io/aeron/socks5-dante-proxy:latest
 ```
 
 Replace the `/path/to/passwd` and `/path/to/shadow` with preferred file paths.


### PR DESCRIPTION
May be something wrong, but docker.io/aeron/socks5-dante-docker:latest doesn't exist and docker.io/aeron/socks5-dante-proxy:latest works